### PR TITLE
Include support for ESP32 boards

### DIFF
--- a/src/RaceChrono.cpp
+++ b/src/RaceChrono.cpp
@@ -1,9 +1,14 @@
 #include "RaceChrono.h"
 
+#define MAIN_SERVICE_NAME           (uint16_t) 0x1ff8
+#define PID_CHARACTERISTIC          (uint16_t) 0x02
+#define CANBUS_CHARACTERISTIC       (uint16_t) 0x01
+
 namespace {
 
 RaceChronoBleCanHandler *handler = nullptr;
 
+#if defined(ARDUINO_ARCH_NRF52)
 void handle_racechrono_filter_request(
     uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *data, uint16_t len) {
   if (len < 1) {
@@ -39,18 +44,71 @@ void handle_racechrono_filter_request(
 
   // TODO: figure out how to report errors.
 }
+#elif defined(ARDUINO_ARCH_ESP32)
+class handle_racechrono_filter_request: public NimBLECharacteristicCallbacks {
+
+  void onWrite(BLECharacteristic* pCharacteristic) {
+    std::string data = pCharacteristic->getValue();
+    int len = pCharacteristic->getValue().length();
+    if (len < 1) {
+      // TODO: figure out how to report errors.
+      return;
+    }
+
+    switch (data[0]) {
+      case 1:  // Allow all CAN PIDs.
+        if (len == 3) {
+          uint16_t updateIntervalMs = data[1] << 8 | data[2];
+          handler->allowAllPids(updateIntervalMs);
+          return;
+        }
+        break;
+
+      case 0:  // Deny all CAN PIDs.
+        if (len == 1) {
+          handler->denyAllPids();
+          return;
+        }
+        break;
+
+      case 2:  // Allow one more CAN PID.
+        if (len == 7) {
+          uint16_t updateIntervalMs = data[1] << 8 | data[2];
+          uint32_t pid = data[3] << 24 | data[4] << 16 | data[5] << 8 | data[6];
+          handler->allowPid(pid, updateIntervalMs);
+          return;
+        }
+        break;
+    }
+  }
+};
+#endif
 
 }  // namespace
 
 RaceChronoBleAgent RaceChronoBle;
 
+#if defined(ARDUINO_ARCH_NRF52)
 RaceChronoBleAgent::RaceChronoBleAgent() :
-  _service(/* uuid= */ 0x00000001000000fd8933990d6f411ff8),
-  _pidRequestsCharacteristic(0x02),
-  _canBusDataCharacteristic(0x01)
+  _service(/* uuid= */ MAIN_SERVICE_NAME),
+  _pidRequestsCharacteristic(PID_CHARACTERISTIC),
+  _canBusDataCharacteristic(CANBUS_CHARACTERISTIC)
+{
+}
+#elif defined(ARDUINO_ARCH_ESP32)
+RaceChronoBleAgent::RaceChronoBleAgent() :
+  BTName(),
+  pServer(),
+  pMainService(),
+  _pidRequestsCharacteristic(),
+  _canBusDataCharacteristic()
 {
 }
 
+static handle_racechrono_filter_request cbhandle_racechrono_filter_request;
+#endif
+
+#if defined(ARDUINO_ARCH_NRF52)
 void RaceChronoBleAgent::setUp(
     const char *bluetoothName, RaceChronoBleCanHandler *handler) {
   ::handler = handler;
@@ -72,7 +130,34 @@ void RaceChronoBleAgent::setUp(
 
   Bluefruit.setTxPower(+4);
 }
+#elif defined(ARDUINO_ARCH_ESP32)
+void RaceChronoBleAgent::setUp(
+    const char *bluetoothName, RaceChronoBleCanHandler *handler) {
+  ::handler = handler;
+  BTName = bluetoothName;
+  BLEDevice::init(BTName);
+  BLEDevice::setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT);
+  pServer = BLEDevice::createServer();
+  pMainService = pServer->createService(MAIN_SERVICE_NAME);
 
+  _pidRequestsCharacteristic = pMainService->createCharacteristic( 
+                PID_CHARACTERISTIC, 
+                NIMBLE_PROPERTY::WRITE
+                );
+  _pidRequestsCharacteristic->setCallbacks(&cbhandle_racechrono_filter_request);
+
+  _canBusDataCharacteristic = pMainService->createCharacteristic( 
+                CANBUS_CHARACTERISTIC, 
+                NIMBLE_PROPERTY::READ |
+                NIMBLE_PROPERTY::NOTIFY
+                );
+  pMainService->start();
+  
+}
+#endif
+
+
+#if defined(ARDUINO_ARCH_NRF52)
 void RaceChronoBleAgent::startAdvertising() {
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
@@ -106,6 +191,39 @@ bool RaceChronoBleAgent::isConnected() const {
   return Bluefruit.connected();
 }
 
+#elif defined(ARDUINO_ARCH_ESP32)
+
+void RaceChronoBleAgent::startAdvertising() {
+  
+  NimBLEAdvertising* pAdvertising = NimBLEDevice::getAdvertising();
+  pAdvertising->setName(BTName);
+  pAdvertising->setMinInterval(32);
+  pAdvertising->setMaxInterval(160);
+  pAdvertising->addServiceUUID(pMainService->getUUID());
+  pAdvertising->setScanResponse(false);
+  pAdvertising->start();
+}
+
+bool RaceChronoBleAgent::waitForConnection(uint32_t timeoutMs) {
+  uint32_t startTimeMs = millis();
+  while (!isConnected()) {
+    if (millis() - startTimeMs >= timeoutMs) {
+      return false;
+    }
+    delay(100);
+  }
+
+  return true;
+}
+
+bool RaceChronoBleAgent::isConnected() const {
+  int32_t connectedCount;
+  connectedCount = pServer->getConnectedCount();
+  return (connectedCount > 0);
+}
+#endif
+
+
 void RaceChronoBleAgent::sendCanData(
     uint32_t pid, const uint8_t *data, uint8_t len) {
   if (len > 8) {
@@ -118,5 +236,10 @@ void RaceChronoBleAgent::sendCanData(
   buffer[2] = (pid >> 16) & 0xFF;
   buffer[3] = (pid >> 24) & 0xFF;
   memcpy(buffer + 4, data, len);
+#if defined(ARDUINO_ARCH_NRF52)
   _canBusDataCharacteristic.notify(buffer, 4 + len);
+#elif defined(ARDUINO_ARCH_ESP32)
+  _canBusDataCharacteristic->setValue(buffer, 4 + len);
+  _canBusDataCharacteristic->notify();
+#endif
 }

--- a/src/RaceChrono.h
+++ b/src/RaceChrono.h
@@ -1,7 +1,12 @@
 #ifndef __RACECHRONO_H
 #define __RACECHRONO_H
+#include <Arduino.h>
 
-#include <bluefruit.h>
+#if defined(ARDUINO_ARCH_NRF52)
+  #include <bluefruit.h>
+#elif defined(ARDUINO_ARCH_ESP32)
+  #include <NimBLEDevice.h>
+#endif
 
 #include "RaceChronoPidMap.h"
 
@@ -36,14 +41,22 @@ private:
 
   // BLEService docs: https://learn.adafruit.com/bluefruit-nrf52-feather-learning-guide/bleservice
   // BLECharacteristic docs: https://learn.adafruit.com/bluefruit-nrf52-feather-learning-guide/blecharacteristic
-
+  #if defined(ARDUINO_ARCH_NRF52)
   BLEService _service;
 
   // RaceChrono uses two BLE characteristics:
   // 1) 0x02 to request which PIDs to send, and how frequently
   // 2) 0x01 to be notified of data received for those PIDs
+  
   BLECharacteristic _pidRequestsCharacteristic;
   BLECharacteristic _canBusDataCharacteristic;
+  #elif defined(ARDUINO_ARCH_ESP32)
+  BLEServer* pServer;
+  BLEService* pMainService;
+  std::string BTName;
+  NimBLECharacteristic* _pidRequestsCharacteristic;
+  NimBLECharacteristic* _canBusDataCharacteristic;
+  #endif
 };
 
 extern RaceChronoBleAgent RaceChronoBle;


### PR DESCRIPTION
Added support for ESP32 boards.
Tested using a [RejsaCAN ESP32](https://github.com/MagnusThome/RejsaCAN-ESP32) v2.3.  Only one line needs to be changed in RaceChronoDiyBleDevice which refers directly to the bluefruit library.
The only testing performed has been rudimentary, so this PR is mainly for comments while I prove it further.